### PR TITLE
Fixes bug when initializing UART with defined rx and tx pins.

### DIFF
--- a/src/dfplayer/__init__.py
+++ b/src/dfplayer/__init__.py
@@ -9,9 +9,7 @@ class DFPlayer:
                 
         #not all boards can set the pins for the uart channel
         if tx_pin_id or rx_pin_id:
-            self.tx_pin=machine.Pin(tx_pin_id,machine.Pin.OUT)
-            self.rx_pin=machine.Pin(rx_pin_id,machine.Pin.IN)     
-            self.uart.init(9600, bits=8, parity=None, stop=1, tx=self.tx_pin, rx=self.rx_pin)
+            self.uart.init(9600, bits=8, parity=None, stop=1, tx=tx_pin_id, rx=rx_pin_id)
         else:
             self.uart.init(9600, bits=8, parity=None, stop=1)
         


### PR DESCRIPTION
Thanks for a great repo. I got the DFPlayer playing in no time with it.
This PR fixes a bug when initialization UART defining rx and tx pins. uart.init() takes ints as parameters to tx and rx, not machine.Pin types.
Fix works on micropython esp32-20230426-v1.20.0.bin